### PR TITLE
Update KenesWidget.swift

### DIFF
--- a/Sources/KenesWidget/KenesWidget.swift
+++ b/Sources/KenesWidget/KenesWidget.swift
@@ -10,7 +10,6 @@ public final class KenesWidet: SFSafariViewController {
         }
 
         let config = SFSafariViewController.Configuration()
-        config.entersReaderIfAvailable = true
         config.barCollapsingEnabled = true
         
         super.init(url: widgetURL, configuration: config)


### PR DESCRIPTION
Убрал `entersreaderifavailable = true` потому что от этого бывают проблемы на вебке. Думаю, здесь это поле было использовано по ошибке.
 https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller/configuration/1648471-entersreaderifavailable